### PR TITLE
Listando membros com transformer

### DIFF
--- a/app/Entities/ProjectMember.php
+++ b/app/Entities/ProjectMember.php
@@ -8,6 +8,17 @@ use Prettus\Repository\Traits\TransformableTrait;
 
 class ProjectMember extends Model implements Transformable {
     use TransformableTrait;
-    protected $fillable = [];
+
+    protected $fillable = [
+        'project_id',
+        'user_id',
+        'project_id',
+        'user_id'
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 
 }

--- a/app/Services/ProjectService.php
+++ b/app/Services/ProjectService.php
@@ -62,12 +62,7 @@ class ProjectService {
     }
 
     public function showMembers($projectId) {
-        $projectRepo = $this->projectMemberRepository->findWhere(['project_id'=>$projectId]);
-        dd($projectRepo);
-        die;
-
-        //$project = $this->projectRepository->skipPresenter()->find($projectId);
-        //return $project->projectMembers()->get();
+        return $this->projectMemberRepository->findWhere(['project_id'=>$projectId]);
     }
 
     public function addMember($idProject, array $data) {

--- a/app/Transformers/ProjectMembersTransformer.php
+++ b/app/Transformers/ProjectMembersTransformer.php
@@ -4,14 +4,14 @@ namespace SdcProject\Transformers;
 
 
 use League\Fractal\TransformerAbstract;
+use SdcProject\Entities\ProjectMember;
 use SdcProject\Entities\User;
 
 class ProjectMembersTransformer extends TransformerAbstract {
-    public function transform(User $user) {
+    public function transform(ProjectMember $member) {
         return [
-            'id' => $user->id,
-            'name' => $user->name,
-            'email' => $user->email
+            'member_id' => $member->user->id,
+            'name' => $member->user->name,
         ];
     }
 }

--- a/app/Transformers/ProjectTransformer.php
+++ b/app/Transformers/ProjectTransformer.php
@@ -32,8 +32,9 @@ class ProjectTransformer extends TransformerAbstract {
         return $this->item($project->client, new ClientTransformer());
     }
 
-    public function includeProjectMembers(Project $project) {
-        return $this->collection($project->projectMembers, new ProjectMembersTransformer());
+    public function includeMembers(Project $project)
+    {
+        return $this->collection($project->members, new ProjectMemberTransformer());
     }
 
 }


### PR DESCRIPTION
No arquivo ProjectMembersTransformer ao invés de receber o User, mudei para ProjectMember.
Acrescentei no model ProjectMember o método User com o relacionamento belongsTo para que no ProjectMembersTransformer pudesse usar um $member->user->id
Então no método showMembers do ProjectService só fiz retornar:
return $this->projectMemberRepository->findWhere(['project_id'=>$projectId]);
Pronto, dessa forma ele já estária usando o presenter/transformer do ProjectMember